### PR TITLE
chore: allow WithEnvironmentVariables param to be `nil`

### DIFF
--- a/options.go
+++ b/options.go
@@ -16,6 +16,9 @@ type EnvironmentVariableOptions struct {
 
 // WithEnvironmentVariables sets the options for loading configuration from environment variables.
 func (c *Configulator[C]) WithEnvironmentVariables(opts *EnvironmentVariableOptions) *Configulator[C] {
+	if opts == nil {
+		opts = &EnvironmentVariableOptions{}
+	}
 	c.envOptions = opts
 	return c
 }


### PR DESCRIPTION
Currently, this function requires `EnvironmentVariableOptions` to be set, otherwise environment variables are not loaded.
```go
config := configulator.New[Config]().
	WithEnvironmentVariables(&configulator.EnvironmentVariableOptions{})
```
This might be more of an opinionated change, but I feel environment variables should be loaded using the default options if the function is called with a `nil` parameter.
```go
config := configulator.New[Config]().WithEnvironmentVariables(nil)
```

The main issue I see from this is that there's no way to disable environment variables after this function has been called. Is that something you would want to support?